### PR TITLE
Add warehouse scanning dashboard with booking and storage tables

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,16 +2,15 @@ import type { Metadata } from 'next';
 import '@/app/globals.css';
 
 export const metadata: Metadata = {
-  title: 'Order & Map Retrieval',
-  description: 'Upload order documents, extract key/value pairs, and retrieve floor maps.',
+  title: 'Warehouse Scanning Console',
+  description:
+    'Scan warehouse tickets, reconcile them with booking records, and monitor storage level updates in real time.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning /* add 'dark' here if you want to force dark: className="dark" */>
-      <body className="transition-colors bg-background text-foreground">
-        {children}
-      </body>
+    <html lang="en" suppressHydrationWarning>
+      <body className="transition-colors bg-background text-foreground">{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,460 @@
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { ThemeToggle } from '@/components/theme-toggle';
+"use client";
 
-/**
- * Home page of the application. It introduces the purpose of the app and
- * provides navigation to the upload/scan page. A theme toggle is available
- * in the header for convenience.
- */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { ThemeToggle } from '@/components/theme-toggle';
+import {
+  bookingSamples,
+  storageSamples,
+  OrderFields,
+  StorageRow,
+} from '@/data/orderSamples';
+
+const emptyOrder: OrderFields = {
+  destination: '',
+  itemName: '',
+  trackingId: '',
+  truckNumber: '',
+  shipDate: '',
+  expectedDeparture: '',
+  origin: '',
+};
+
+const columnConfig: { key: keyof OrderFields; label: string }[] = [
+  { key: 'destination', label: 'Destination (Rack Number)' },
+  { key: 'itemName', label: 'Item Name' },
+  { key: 'trackingId', label: 'Tracking ID' },
+  { key: 'truckNumber', label: 'Truck Number' },
+  { key: 'shipDate', label: 'Ship Date' },
+  { key: 'expectedDeparture', label: 'Expected Departure Time' },
+  { key: 'origin', label: 'Origin' },
+];
+
+type EditableStorageField = 'destination' | 'trackingId' | 'expectedDeparture';
+
+interface ScannedRecord extends OrderFields {
+  scannedAt: string;
+}
+
+interface CurrentScanState {
+  raw: ScannedRecord;
+  resolved: OrderFields;
+  bookingMatch: boolean;
+  bookingMessage: string;
+  storageMatch: boolean;
+  storageMessage: string;
+  storageRowId?: string;
+  lastUpdated: string;
+}
+
+function formatTimestamp(value: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
 export default function HomePage() {
+  const [storageRows, setStorageRows] = useState<StorageRow[]>(() => storageSamples);
+  const [manualForm, setManualForm] = useState<OrderFields>({ ...emptyOrder });
+  const [selectedSample, setSelectedSample] = useState<string>('');
+  const [scannedArchive, setScannedArchive] = useState<ScannedRecord[]>([]);
+  const [currentScan, setCurrentScan] = useState<CurrentScanState | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const bookingLookup = useMemo(() => {
+    const byTracking = new Map<string, OrderFields>();
+    for (const order of bookingSamples) {
+      byTracking.set(order.trackingId, order);
+    }
+    return byTracking;
+  }, []);
+
+  const handleStorageFieldChange = (
+    id: string,
+    field: EditableStorageField,
+    value: string,
+  ) => {
+    setStorageRows((prev) =>
+      prev.map((row) => (row.id === id ? { ...row, [field]: value } : row)),
+    );
+    setStatusMessage(
+      `Storage row ${id} updated: ${field.replace(/([A-Z])/g, ' $1').toLowerCase()} set to ${value || '—'}.`,
+    );
+  };
+
+  const refreshCurrentScan = useCallback(() => {
+    setCurrentScan((prev) => {
+      if (!prev) return prev;
+      const now = new Date().toISOString();
+      if (!prev.storageRowId) {
+        return { ...prev, lastUpdated: now };
+      }
+      const storageRow = storageRows.find((row) => row.id === prev.storageRowId);
+      if (!storageRow) {
+        return {
+          ...prev,
+          storageMatch: false,
+          storageMessage: 'Linked storage row was not found during refresh.',
+          lastUpdated: now,
+        };
+      }
+      return {
+        ...prev,
+        resolved: { ...storageRow },
+        storageMatch: true,
+        storageMessage: `Data refreshed from storage row ${storageRow.id}.`,
+        lastUpdated: now,
+      };
+    });
+  }, [storageRows]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      refreshCurrentScan();
+    }, 300000); // 5 minutes
+    return () => clearInterval(interval);
+  }, [refreshCurrentScan]);
+
+  useEffect(() => {
+    if (currentScan) {
+      refreshCurrentScan();
+    }
+  }, [storageRows, refreshCurrentScan]);
+
+  const handleScan = useCallback(
+    (order: OrderFields) => {
+      const now = new Date();
+      const scanned: ScannedRecord = {
+        ...order,
+        scannedAt: now.toISOString(),
+      };
+      setScannedArchive((prev) => [scanned, ...prev]);
+
+      const bookingMatch = bookingLookup.get(order.trackingId);
+      let bookingMessage = 'Booked item not found in the Booking Table.';
+      let storageMessage = 'Storage lookup skipped because booking was not located.';
+      let resolved: OrderFields = { ...order };
+      let storageRowId: string | undefined;
+      let storageMatch = false;
+
+      if (bookingMatch) {
+        bookingMessage = 'Booking located and verified.';
+        const storageRow = storageRows.find(
+          (row) => row.truckNumber === order.truckNumber && row.shipDate === order.shipDate,
+        );
+        if (storageRow) {
+          resolved = { ...storageRow };
+          storageRowId = storageRow.id;
+          storageMatch = true;
+          storageMessage = `Linked to storage row ${storageRow.id}.`;
+        } else {
+          storageMessage = 'Storage entry not found for the scanned truck and ship date.';
+        }
+      }
+
+      setCurrentScan({
+        raw: scanned,
+        resolved,
+        bookingMatch: Boolean(bookingMatch),
+        bookingMessage,
+        storageMatch,
+        storageMessage,
+        storageRowId,
+        lastUpdated: now.toISOString(),
+      });
+
+      setStatusMessage(
+        !bookingMatch
+          ? 'Scan saved, but the booking entry was not found.'
+          : storageMatch
+          ? `Scan saved. Storage row ${storageRowId} applied.`
+          : 'Scan saved. Storage entry pending.',
+      );
+      setSelectedSample('');
+      setManualForm({ ...emptyOrder });
+    },
+    [bookingLookup, storageRows],
+  );
+
+  const handleManualChange = (field: keyof OrderFields, value: string) => {
+    setManualForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleManualScan = () => {
+    const missing = Object.entries(manualForm).filter(([, value]) => !value.trim());
+    if (missing.length > 0) {
+      setStatusMessage('Please complete all fields before scanning a manual entry.');
+      return;
+    }
+    handleScan(manualForm);
+  };
+
+  const handleSampleScan = () => {
+    if (!selectedSample) {
+      setStatusMessage('Select a booking sample to simulate a scan.');
+      return;
+    }
+    const sample = bookingLookup.get(selectedSample);
+    if (!sample) {
+      setStatusMessage('The selected booking sample could not be found.');
+      return;
+    }
+    handleScan(sample);
+  };
+
   return (
-    <main className="flex flex-col items-center justify-center py-20 px-4 space-y-8">
-      <div className="flex w-full justify-between items-center max-w-3xl">
-        <h1 className="text-3xl font-bold">Order & Map Retrieval</h1>
+    <main className="min-h-screen px-4 py-8 md:px-8 lg:px-12">
+      <header className="flex flex-col gap-4 pb-8 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <h1 className="text-3xl font-bold">Warehouse Scanning Console</h1>
+          <p className="max-w-3xl text-sm text-[var(--color-textSecondary)] md:text-base">
+            Scan printed order tickets, validate them against booking records, and keep storage data in sync.
+            The console maintains an archive of every scan and continuously refreshes the live buffer from storage.
+          </p>
+        </div>
         <ThemeToggle />
-      </div>
-      <p className="text-lg text-[var(--color-textSecondary)] max-w-3xl text-center">
-        Upload a shipping document or order summary, extract the key/value pairs with our
-        OCR-powered pipeline, and retrieve a floor map to help you locate the order in
-        the warehouse. This app is built with Next.js 15, Tailwind CSS v4 and a
-        SQLite-backed microservice architecture.
-      </p>
-      <Link href="/upload" className="mt-4">
-        <Button className='hover:cursor-pointer'>Scan a Document</Button>
-      </Link>
+      </header>
+
+      {statusMessage && (
+        <div className="mb-6 rounded-md border border-dashed border-[var(--color-borderColor)] bg-[var(--color-backgroundSecondary)] px-4 py-3 text-sm">
+          {statusMessage}
+        </div>
+      )}
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card
+          header={<span className="font-semibold">Simulate a Scan with Booking Samples</span>}
+        >
+          <div className="flex flex-col gap-4 md:flex-row md:items-end">
+            <label className="flex-1 text-sm">
+              <span className="mb-2 block font-medium">Booking sample</span>
+              <select
+                className="w-full rounded-md border border-[var(--color-borderColor)] bg-[var(--color-backgroundSecondary)] px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]"
+                value={selectedSample}
+                onChange={(event) => setSelectedSample(event.target.value)}
+              >
+                <option value="">Select a booking to scan…</option>
+                {bookingSamples.map((order) => (
+                  <option key={order.trackingId} value={order.trackingId}>
+                    {order.itemName} — {order.trackingId}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <Button className="hover:cursor-pointer" onClick={handleSampleScan}>
+              Scan Selected Sample
+            </Button>
+          </div>
+        </Card>
+
+        <Card
+          header={<span className="font-semibold">Manual Entry Scan</span>}
+        >
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {columnConfig.map(({ key, label }) => (
+              <label key={key} className="text-sm">
+                <span className="mb-1 block font-medium">{label}</span>
+                <Input
+                  type={key === 'shipDate' ? 'date' : key === 'expectedDeparture' ? 'time' : 'text'}
+                  value={manualForm[key]}
+                  onChange={(event) => handleManualChange(key, event.target.value)}
+                  placeholder={label}
+                />
+              </label>
+            ))}
+          </div>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Button className="hover:cursor-pointer" onClick={handleManualScan}>
+              Scan Manual Entry
+            </Button>
+            <Button
+              className="hover:cursor-pointer"
+              variant="outline"
+              type="button"
+              onClick={() => setManualForm({ ...emptyOrder })}
+            >
+              Clear Form
+            </Button>
+          </div>
+        </Card>
+      </section>
+
+      <section className="mt-8 grid gap-6 lg:grid-cols-2">
+        <Card header={<span className="font-semibold">Booking Table</span>}>
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-auto text-sm">
+              <thead>
+                <tr className="bg-[var(--color-backgroundSecondary)]">
+                  {columnConfig.map(({ key, label }) => (
+                    <th key={key} className="px-3 py-2 text-left font-semibold">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {bookingSamples.map((order) => (
+                  <tr key={order.trackingId} className="border-t border-[var(--color-borderColor)]">
+                    {columnConfig.map(({ key }) => (
+                      <td key={key} className="px-3 py-2 align-top">
+                        {order[key]}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card header={<span className="font-semibold">Storage Table (Live Updates)</span>}>
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-auto text-sm">
+              <thead>
+                <tr className="bg-[var(--color-backgroundSecondary)]">
+                  <th className="px-3 py-2 text-left font-semibold">Storage ID</th>
+                  {columnConfig.map(({ key, label }) => (
+                    <th key={key} className="px-3 py-2 text-left font-semibold">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {storageRows.map((row) => (
+                  <tr key={row.id} className="border-t border-[var(--color-borderColor)]">
+                    <td className="px-3 py-2 align-top font-medium">{row.id}</td>
+                    {columnConfig.map(({ key }) => (
+                      <td key={key} className="px-3 py-2 align-top">
+                        {key === 'destination' || key === 'trackingId' || key === 'expectedDeparture' ? (
+                          <Input
+                            type={key === 'expectedDeparture' ? 'time' : 'text'}
+                            value={row[key]}
+                            onChange={(event) =>
+                              handleStorageFieldChange(row.id, key as EditableStorageField, event.target.value)
+                            }
+                            className="min-w-[7rem]"
+                          />
+                        ) : (
+                          row[key]
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-3 text-xs text-[var(--color-textSecondary)]">
+            Destination, Tracking ID, and Expected Departure Time fields accept live edits. Linked scans refresh every five minutes and whenever storage data changes.
+          </p>
+        </Card>
+      </section>
+
+      <section className="mt-8 grid gap-6 lg:grid-cols-2">
+        <Card header={<span className="font-semibold">Table 1 — Scanned Orders Archive</span>}>
+          <div className="overflow-x-auto">
+            <table className="min-w-full table-auto text-sm">
+              <thead>
+                <tr className="bg-[var(--color-backgroundSecondary)]">
+                  {columnConfig.map(({ key, label }) => (
+                    <th key={key} className="px-3 py-2 text-left font-semibold">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {scannedArchive.length === 0 ? (
+                  <tr>
+                    <td colSpan={columnConfig.length} className="px-3 py-4 text-center text-[var(--color-textSecondary)]">
+                      Scan an order ticket to populate the archive.
+                    </td>
+                  </tr>
+                ) : (
+                  scannedArchive.map((record) => (
+                    <tr
+                      key={`${record.trackingId}-${record.scannedAt}`}
+                      className="border-t border-[var(--color-borderColor)]"
+                    >
+                      {columnConfig.map(({ key }) => (
+                        <td key={key} className="px-3 py-2 align-top">
+                          {record[key]}
+                        </td>
+                      ))}
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <Card header={<span className="font-semibold">Table 2 — Current Scan Buffer & Validation</span>}>
+          <div className="space-y-4">
+            <div className="rounded-md border border-[var(--color-borderColor)] bg-[var(--color-backgroundSecondary)] px-3 py-2 text-sm">
+              <p className="font-medium">Booking Check</p>
+              <p className={currentScan?.bookingMatch ? 'text-green-600' : 'text-red-600'}>
+                {currentScan ? currentScan.bookingMessage : 'Awaiting scan.'}
+              </p>
+            </div>
+            <div className="rounded-md border border-[var(--color-borderColor)] bg-[var(--color-backgroundSecondary)] px-3 py-2 text-sm">
+              <p className="font-medium">Storage Check</p>
+              <p className={currentScan?.storageMatch ? 'text-green-600' : 'text-amber-600'}>
+                {currentScan
+                  ? currentScan.storageMessage
+                  : 'Storage data will be evaluated after a scan is recorded.'}
+              </p>
+              {currentScan?.storageRowId && (
+                <p className="mt-1 text-xs text-[var(--color-textSecondary)]">
+                  Tracking storage row: {currentScan.storageRowId}. Last updated {formatTimestamp(currentScan.lastUpdated)}.
+                </p>
+              )}
+            </div>
+            <div className="overflow-x-auto">
+              <table className="min-w-full table-auto text-sm">
+                <thead>
+                  <tr className="bg-[var(--color-backgroundSecondary)]">
+                    {columnConfig.map(({ key, label }) => (
+                      <th key={key} className="px-3 py-2 text-left font-semibold">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {currentScan ? (
+                    <tr className="border-t border-[var(--color-borderColor)]">
+                      {columnConfig.map(({ key }) => (
+                        <td key={key} className="px-3 py-2 align-top">
+                          {currentScan.resolved[key]}
+                        </td>
+                      ))}
+                    </tr>
+                  ) : (
+                    <tr>
+                      <td colSpan={columnConfig.length} className="px-3 py-4 text-center text-[var(--color-textSecondary)]">
+                        Waiting for the first scan.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <Button className="hover:cursor-pointer" variant="outline" onClick={() => refreshCurrentScan()}>
+                Refresh from Storage Now
+              </Button>
+              <p className="text-xs text-[var(--color-textSecondary)]">
+                Automatic refresh runs every 5 minutes and whenever storage data changes.
+              </p>
+            </div>
+          </div>
+        </Card>
+      </section>
     </main>
   );
 }

--- a/src/data/orderSamples.ts
+++ b/src/data/orderSamples.ts
@@ -1,0 +1,166 @@
+export interface OrderFields {
+  destination: string;
+  itemName: string;
+  trackingId: string;
+  truckNumber: string;
+  shipDate: string; // YYYY-MM-DD
+  expectedDeparture: string; // HH:mm in 24-hour format
+  origin: string;
+}
+
+export interface StorageRow extends OrderFields {
+  id: string;
+}
+
+export const bookingSamples: OrderFields[] = [
+  {
+    destination: 'D73',
+    itemName: 'Automotive Parts',
+    trackingId: 'TR6254',
+    truckNumber: 'TRK-6254',
+    shipDate: '2025-06-28',
+    expectedDeparture: '13:15',
+    origin: 'WH-08',
+  },
+  {
+    destination: 'D27',
+    itemName: 'Construction Supplies',
+    trackingId: '567891234509876543F',
+    truckNumber: 'TRK-3156',
+    shipDate: '2025-09-30',
+    expectedDeparture: '13:00',
+    origin: 'WH-02',
+  },
+  {
+    destination: 'C28',
+    itemName: 'Premium Laptops',
+    trackingId: '764589321598764321B',
+    truckNumber: 'TRK-4578',
+    shipDate: '2025-03-24',
+    expectedDeparture: '07:30',
+    origin: 'WH-03',
+  },
+  {
+    destination: 'A23',
+    itemName: 'Acme Widgets',
+    trackingId: '987654112349588725G',
+    truckNumber: 'TRK-1285',
+    shipDate: '2025-10-15',
+    expectedDeparture: '08:00',
+    origin: 'WH-01',
+  },
+  {
+    destination: 'B14',
+    itemName: 'Industrial Bolts',
+    trackingId: 'IND-441022',
+    truckNumber: 'TRK-2209',
+    shipDate: '2025-04-12',
+    expectedDeparture: '09:45',
+    origin: 'WH-05',
+  },
+  {
+    destination: 'E11',
+    itemName: 'Cooling Fans',
+    trackingId: 'CF-884210',
+    truckNumber: 'TRK-9031',
+    shipDate: '2025-04-18',
+    expectedDeparture: '11:30',
+    origin: 'WH-04',
+  },
+  {
+    destination: 'F07',
+    itemName: 'Optical Sensors',
+    trackingId: 'OS-550012',
+    truckNumber: 'TRK-7310',
+    shipDate: '2025-05-02',
+    expectedDeparture: '15:00',
+    origin: 'WH-06',
+  },
+  {
+    destination: 'B09',
+    itemName: 'Hydraulic Pumps',
+    trackingId: 'HP-903842',
+    truckNumber: 'TRK-6425',
+    shipDate: '2025-05-20',
+    expectedDeparture: '10:20',
+    origin: 'WH-02',
+  },
+  {
+    destination: 'G18',
+    itemName: 'Alloy Sheets',
+    trackingId: 'AS-772109',
+    truckNumber: 'TRK-8744',
+    shipDate: '2025-06-05',
+    expectedDeparture: '16:45',
+    origin: 'WH-07',
+  },
+  {
+    destination: 'C11',
+    itemName: 'Safety Helmets',
+    trackingId: 'SH-110234',
+    truckNumber: 'TRK-5120',
+    shipDate: '2025-06-17',
+    expectedDeparture: '12:00',
+    origin: 'WH-03',
+  },
+];
+
+const bookingStorageRows: StorageRow[] = bookingSamples.map((order, index) => ({
+  id: `ST-${String(index + 1).padStart(3, '0')}`,
+  ...order,
+}));
+
+const extraStorageRows: StorageRow[] = [
+  {
+    id: 'ST-011',
+    destination: 'H05',
+    itemName: 'Packaging Film',
+    trackingId: 'PF-659002',
+    truckNumber: 'TRK-9910',
+    shipDate: '2025-07-01',
+    expectedDeparture: '09:00',
+    origin: 'WH-04',
+  },
+  {
+    id: 'ST-012',
+    destination: 'E19',
+    itemName: 'Circuit Boards',
+    trackingId: 'CB-340022',
+    truckNumber: 'TRK-4570',
+    shipDate: '2025-07-10',
+    expectedDeparture: '13:45',
+    origin: 'WH-08',
+  },
+  {
+    id: 'ST-013',
+    destination: 'F15',
+    itemName: 'Lithium Batteries',
+    trackingId: 'LB-902340',
+    truckNumber: 'TRK-5885',
+    shipDate: '2025-07-14',
+    expectedDeparture: '14:30',
+    origin: 'WH-06',
+  },
+  {
+    id: 'ST-014',
+    destination: 'D05',
+    itemName: 'Fiber Optic Cable',
+    trackingId: 'FO-776543',
+    truckNumber: 'TRK-3411',
+    shipDate: '2025-07-22',
+    expectedDeparture: '08:20',
+    origin: 'WH-05',
+  },
+  {
+    id: 'ST-015',
+    destination: 'J02',
+    itemName: 'Industrial Lubricant',
+    trackingId: 'IL-982210',
+    truckNumber: 'TRK-7802',
+    shipDate: '2025-07-30',
+    expectedDeparture: '17:00',
+    origin: 'WH-09',
+  },
+];
+
+export const storageSamples: StorageRow[] = [...bookingStorageRows, ...extraStorageRows];


### PR DESCRIPTION
## Summary
- replace the home page with a warehouse scanning console that simulates scans, validates against booking and storage tables, and keeps a live buffer in sync
- seed the new booking and storage tables with 10 booking entries plus 5 extra storage rows based on the provided sample tickets
- update the app metadata to reflect the new scanning-focused experience

## Testing
- npm run lint *(fails: requires interactive Next.js configuration so the command was cancelled)*

