### PR TITLE
Add floor map administration and navigation module

### DIFF
--- a/docs/map-testing.md
+++ b/docs/map-testing.md
@@ -1,0 +1,30 @@
+# Floor Map QA Scenarios
+
+This document captures the manual checks run against the floor-map workflow. The goal is to verify multi-map coverage, destination lookups, and navigation hand-off without regressions.
+
+## Prerequisites
+
+1. Open the Home dashboard and scroll to **Map Administration**.
+2. Upload at least three floor variants using the built-in uploader. For quick testing you can reuse the sample PNGs already bundled with the app (`public/maps/floor1.png`, `floor1-section-a.png`, `floor2.png`).
+3. Annotate each map with a handful of destinations. For example:
+   - `floor1`: add points for `Dock 3`, `R1-A`, and `W9`.
+   - `floor1-section-a`: add `D3` as a synonym of `Dock 3` and mark a distinct rack (e.g., `A-12`).
+   - `floor2`: add a high-bay label such as `WH-12` and a staging zone (`Outbound B`).
+4. Provide approximate georeference details (origin, scale, rotation) or leave defaults if precise indoor GPS is not available—the module will still derive consistent lat/lon pairs from pixel coordinates.
+
+## Scenario Matrix
+
+| Scenario | Steps | Expected Result |
+| --- | --- | --- |
+| Multi-map coverage | Upload the three maps above, then open each one in the admin panel to confirm annotations render and can be edited. | All maps list their annotated points, and the overlay markers appear in the click-to-annotate preview. |
+| Destination change | Use **Load Camera Demo** twice to cycle through sample OCR payloads. Observe the **Floor Map Navigation** panel. | The destination card updates immediately, the marker jumps to the mapped point on the selected map, and status text reflects the new label. |
+| Synonym resolution | Annotate a point with synonyms (`Dock 3`, `D3`, `Bay 3`). Scan an order containing `D3`. | The runtime lookup resolves to the `Dock 3` pin automatically. Suggestions list stays empty because an exact synonym matched. |
+| Ambiguity fallback | Temporarily remove one synonym, scan `D3` again. | No exact match is found; the suggestions panel lists nearby matches. Clicking a suggestion selects it and updates the navigation payload preview. |
+| Navigation stub | With a match selected, click **Start Navigation**. | A POST request to `/api/navigation/start` succeeds, and the UI confirms the payload queued state. |
+| Refresh guard | Leave the dashboard idle for five minutes (or refresh the page after that interval). | Uploaded maps and annotations persist; re-running a scan still resolves the same coordinates without errors. |
+
+## Notes
+
+- All coordinates are derived from the map’s georeference. Even with approximate indoor GPS values, the payload always includes both `{lat, lon}` and the exact `{x_px, y_px}` for downstream modules.
+- The module can operate with coarse geodata. When no origin is specified the UI still surfaces the local pixel coordinates, allowing the navigation service to align against indoor positioning systems.
+- The admin uploader accepts common web image formats (PNG, JPG, SVG, WebP). Uploaded files are stored in `data/maps/` and served via `/api/floor-maps/{id}/image`.

--- a/src/app/api/floor-maps/[id]/image/route.ts
+++ b/src/app/api/floor-maps/[id]/image/route.ts
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import path from 'path';
+import { NextResponse } from 'next/server';
+import { getFloorMapById } from '@/lib/db';
+
+const DATA_DIR = path.join(process.cwd(), 'data', 'maps');
+const PUBLIC_DIR = path.join(process.cwd(), 'public', 'maps');
+
+const resolveImagePath = (fileName: string) => {
+  const dataPath = path.join(DATA_DIR, fileName);
+  if (fs.existsSync(dataPath)) return dataPath;
+  const publicPath = path.join(PUBLIC_DIR, fileName);
+  if (fs.existsSync(publicPath)) return publicPath;
+  return null;
+};
+
+const lookupContentType = (fileName: string) => {
+  const ext = path.extname(fileName).toLowerCase();
+  switch (ext) {
+    case '.svg':
+      return 'image/svg+xml';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    default:
+      return 'image/png';
+  }
+};
+
+export function GET(_: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const map = getFloorMapById(id);
+  if (!map) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  const filePath = resolveImagePath(map.image_path);
+  if (!filePath) {
+    return NextResponse.json({ error: 'Image not found' }, { status: 404 });
+  }
+  const buffer = fs.readFileSync(filePath);
+  return new NextResponse(buffer, {
+    headers: {
+      'Content-Type': lookupContentType(map.image_path),
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/src/app/api/floor-maps/[id]/points/route.ts
+++ b/src/app/api/floor-maps/[id]/points/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createMapPoint, getFloorMapById, listMapPoints } from '@/lib/db';
+
+export function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  const mapId = Number(params.id);
+  if (!Number.isFinite(mapId)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const map = getFloorMapById(mapId);
+  if (!map) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  const points = listMapPoints(mapId);
+  return NextResponse.json({ points });
+}
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const mapId = Number(params.id);
+  if (!Number.isFinite(mapId)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const map = getFloorMapById(mapId);
+  if (!map) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  const payload = await request.json();
+  const label = typeof payload.label === 'string' ? payload.label.trim() : '';
+  const x = Number(payload.x_px);
+  const y = Number(payload.y_px);
+  if (!label) {
+    return NextResponse.json({ error: 'Label is required' }, { status: 400 });
+  }
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return NextResponse.json({ error: 'x_px and y_px must be numeric' }, { status: 400 });
+  }
+  const synonyms: string[] = Array.isArray(payload.synonyms) ? payload.synonyms : [];
+  if (x < 0 || y < 0 || x > map.width || y > map.height) {
+    return NextResponse.json({ error: 'Point is outside the map bounds' }, { status: 400 });
+  }
+  const point = createMapPoint({
+    mapId,
+    label,
+    x_px: x,
+    y_px: y,
+    synonyms,
+  });
+  return NextResponse.json({ point }, { status: 201 });
+}

--- a/src/app/api/floor-maps/[id]/points/search/route.ts
+++ b/src/app/api/floor-maps/[id]/points/search/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFloorMapById, searchMapPoint } from '@/lib/db';
+
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+  const mapId = Number(params.id);
+  if (!Number.isFinite(mapId)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const map = getFloorMapById(mapId);
+  if (!map) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  const payload = await request.json();
+  const label = typeof payload.label === 'string' ? payload.label : '';
+  const result = searchMapPoint(mapId, label);
+  return NextResponse.json({ map: { ...map, image_url: `/api/floor-maps/${map.id}/image` }, ...result });
+}

--- a/src/app/api/floor-maps/[id]/route.ts
+++ b/src/app/api/floor-maps/[id]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFloorMapById, listMapPoints, updateFloorMap } from '@/lib/db';
+
+const parseNumber = (value: unknown): number | null => {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const num = Number(trimmed);
+    return Number.isFinite(num) ? num : null;
+  }
+  return null;
+};
+
+const serializeMap = (map: ReturnType<typeof getFloorMapById>) => {
+  if (!map) return null;
+  return {
+    ...map,
+    image_url: `/api/floor-maps/${map.id}/image`,
+  };
+};
+
+export function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const map = getFloorMapById(id);
+  if (!map) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  const points = listMapPoints(id);
+  return NextResponse.json({ map: serializeMap(map), points });
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) {
+    return NextResponse.json({ error: 'Invalid map id' }, { status: 400 });
+  }
+  const payload = await request.json();
+  const updated = updateFloorMap(id, {
+    name: typeof payload.name === 'string' ? payload.name : undefined,
+    floor: typeof payload.floor === 'string' ? payload.floor : undefined,
+    georefOriginLat: parseNumber(payload.georef_origin_lat),
+    georefOriginLon: parseNumber(payload.georef_origin_lon),
+    georefRotationDeg: parseNumber(payload.georef_rotation_deg),
+    georefScaleMetersPerPixel: parseNumber(payload.georef_scale_m_per_px),
+  });
+  if (!updated) {
+    return NextResponse.json({ error: 'Map not found' }, { status: 404 });
+  }
+  return NextResponse.json({ map: serializeMap(updated) });
+}

--- a/src/app/api/floor-maps/route.ts
+++ b/src/app/api/floor-maps/route.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+import { NextRequest, NextResponse } from 'next/server';
+import { createFloorMap, listFloorMaps } from '@/lib/db';
+
+const MAPS_DIR = path.join(process.cwd(), 'data', 'maps');
+
+const ensureDir = () => {
+  if (!fs.existsSync(MAPS_DIR)) fs.mkdirSync(MAPS_DIR, { recursive: true });
+};
+
+const parseNumber = (value: FormDataEntryValue | null): number | null => {
+  if (value == null) return null;
+  const str = typeof value === 'string' ? value.trim() : String(value);
+  if (!str) return null;
+  const num = Number(str);
+  return Number.isFinite(num) ? num : null;
+};
+
+const serializeMap = (map: ReturnType<typeof listFloorMaps>[number]) => ({
+  ...map,
+  image_url: `/api/floor-maps/${map.id}/image`,
+});
+
+export async function GET() {
+  const maps = listFloorMaps();
+  return NextResponse.json({ maps: maps.map(serializeMap) });
+}
+
+export async function POST(request: NextRequest) {
+  const formData = await request.formData();
+  const file = formData.get('image');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'Image file is required.' }, { status: 400 });
+  }
+  const name = (formData.get('name') as string | null)?.trim() || file.name || 'Uploaded Map';
+  const floor = (formData.get('floor') as string | null)?.trim() || 'floor-1';
+  const rotation = parseNumber(formData.get('georef_rotation_deg'));
+  const originLat = parseNumber(formData.get('georef_origin_lat'));
+  const originLon = parseNumber(formData.get('georef_origin_lon'));
+  const scale = parseNumber(formData.get('georef_scale_m_per_px'));
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  ensureDir();
+  const ext = path.extname(file.name || 'map.png') || '.png';
+  const filename = `${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`;
+  const filePath = path.join(MAPS_DIR, filename);
+  fs.writeFileSync(filePath, buffer);
+  const metadata = await sharp(buffer).metadata();
+  const width = metadata.width ?? 0;
+  const height = metadata.height ?? 0;
+
+  const map = createFloorMap({
+    name,
+    imagePath: filename,
+    width,
+    height,
+    georefOriginLat: originLat,
+    georefOriginLon: originLon,
+    georefRotationDeg: rotation,
+    georefScaleMetersPerPixel: scale,
+    floor,
+  });
+
+  return NextResponse.json({ map: serializeMap({ ...map, point_count: 0 }) }, { status: 201 });
+}

--- a/src/app/api/navigation/start/route.ts
+++ b/src/app/api/navigation/start/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const payload = await request.json();
+  return NextResponse.json({ status: 'queued', received_at: new Date().toISOString(), payload });
+}

--- a/src/components/maps/floor-map-module.tsx
+++ b/src/components/maps/floor-map-module.tsx
@@ -1,0 +1,669 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+type BaseFloorMap = {
+  id: number;
+  name: string;
+  image_path: string;
+  width: number;
+  height: number;
+  georef_origin_lat: number | null;
+  georef_origin_lon: number | null;
+  georef_rotation_deg: number | null;
+  georef_scale_m_per_px: number | null;
+  floor: string;
+  created_at: string;
+  updated_at: string;
+  image_url: string;
+};
+
+type FloorMapSummary = BaseFloorMap & { point_count: number };
+
+type MapPoint = {
+  id: number;
+  map_id: number;
+  label: string;
+  x_px: number;
+  y_px: number;
+  lat: number | null;
+  lon: number | null;
+  created_at: string;
+  updated_at: string;
+  synonyms: string[];
+};
+
+interface FloorMapModuleProps {
+  destinationLabel?: string;
+  floorHint?: string;
+  sectionHint?: string;
+  lastUpdatedKey?: string | number;
+}
+
+interface SearchResult {
+  match: MapPoint | null;
+  alternatives: MapPoint[];
+}
+
+const initialUploadState = {
+  name: "",
+  floor: "",
+  originLat: "",
+  originLon: "",
+  rotation: "",
+  scale: "",
+};
+
+const formatCoord = (value: number | null) => {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(6);
+};
+
+const formatMetric = (value: number | null, unit: string) => {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${value.toFixed(2)} ${unit}`;
+};
+
+const normalize = (value?: string) => value?.toLowerCase().trim() ?? "";
+
+const parseSynonyms = (value: string): string[] =>
+  value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+const buildMarkerStyle = (point: Pick<MapPoint, "x_px" | "y_px">, map: Pick<FloorMapSummary, "width" | "height">) => {
+  const left = (point.x_px / map.width) * 100;
+  const top = (point.y_px / map.height) * 100;
+  return {
+    left: `${left}%`,
+    top: `${top}%`,
+  } as const;
+};
+
+export function FloorMapModule({ destinationLabel, floorHint, sectionHint, lastUpdatedKey }: FloorMapModuleProps) {
+  const [maps, setMaps] = useState<FloorMapSummary[]>([]);
+  const [loadingMaps, setLoadingMaps] = useState(false);
+  const [mapError, setMapError] = useState<string | null>(null);
+  const [selectedMapId, setSelectedMapId] = useState<number | null>(null);
+  const [mapDetail, setMapDetail] = useState<{ map: FloorMapSummary; points: MapPoint[] } | null>(null);
+  const [mapImageUrl, setMapImageUrl] = useState<string | null>(null);
+  const [searchResult, setSearchResult] = useState<SearchResult>({ match: null, alternatives: [] });
+  const [selectedPoint, setSelectedPoint] = useState<MapPoint | null>(null);
+  const [searchStatus, setSearchStatus] = useState<string | null>(null);
+  const [navStatus, setNavStatus] = useState<string | null>(null);
+  const [uploadState, setUploadState] = useState(initialUploadState);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [adminStatus, setAdminStatus] = useState<string | null>(null);
+  const [draftPoint, setDraftPoint] = useState<{ x: number; y: number } | null>(null);
+  const [annotationLabel, setAnnotationLabel] = useState("");
+  const [annotationSynonyms, setAnnotationSynonyms] = useState("");
+  const [annotationSaving, setAnnotationSaving] = useState(false);
+  const mapClickRef = useRef<HTMLDivElement | null>(null);
+
+  const refreshMaps = useCallback(async () => {
+    try {
+      setLoadingMaps(true);
+      setMapError(null);
+      const res = await fetch("/api/floor-maps");
+      if (!res.ok) throw new Error(await res.text());
+      const data = (await res.json()) as { maps: FloorMapSummary[] };
+      setMaps(data.maps);
+    } catch (err) {
+      console.error(err);
+      setMapError("Failed to load floor maps.");
+    } finally {
+      setLoadingMaps(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshMaps();
+  }, [refreshMaps]);
+
+  useEffect(() => {
+    if (!maps.length) return;
+    if (selectedMapId && maps.some((map) => map.id === selectedMapId)) return;
+    const targetSection = normalize(sectionHint);
+    const targetFloor = normalize(floorHint);
+    const sectionMatch = targetSection
+      ? maps.find((map) => {
+          const name = normalize(map.name);
+          const image = normalize(map.image_path);
+          return name.includes(targetSection) || image.includes(targetSection);
+        })
+      : undefined;
+    const floorMatch = maps.find((map) => normalize(map.floor) === targetFloor);
+    const next = sectionMatch ?? floorMatch ?? maps[0];
+    setSelectedMapId(next?.id ?? null);
+  }, [maps, selectedMapId, floorHint, sectionHint]);
+
+  useEffect(() => {
+    if (!selectedMapId) {
+      setMapDetail(null);
+      setMapImageUrl(null);
+      return;
+    }
+    let cancelled = false;
+    const loadDetail = async () => {
+      try {
+        setSearchStatus("Loading map…");
+        const res = await fetch(`/api/floor-maps/${selectedMapId}`);
+        if (!res.ok) throw new Error(await res.text());
+        const data = (await res.json()) as { map: BaseFloorMap; points: MapPoint[] };
+        if (cancelled) return;
+        const enrichedMap: FloorMapSummary = {
+          ...data.map,
+          point_count: data.points.length,
+        };
+        setMapDetail({ map: enrichedMap, points: data.points });
+        setMapImageUrl(`${data.map.image_url}?ts=${Date.now()}`);
+      } catch (err) {
+        console.error(err);
+        if (!cancelled) {
+          setSearchStatus("Failed to load map detail.");
+          setMapDetail(null);
+          setMapImageUrl(null);
+        }
+      }
+    };
+    loadDetail();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedMapId]);
+
+  useEffect(() => {
+    const label = destinationLabel?.trim();
+    if (!selectedMapId || !label) {
+      setSearchResult({ match: null, alternatives: [] });
+      setSelectedPoint(null);
+      if (!label) setSearchStatus("Awaiting destination from scan.");
+      return;
+    }
+    const controller = new AbortController();
+    const fetchMatch = async () => {
+      try {
+        setSearchStatus("Resolving destination on map…");
+        const res = await fetch(`/api/floor-maps/${selectedMapId}/points/search`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ label, lastUpdatedKey }),
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(await res.text());
+        const data = (await res.json()) as { match: MapPoint | null; alternatives: MapPoint[] };
+        setSearchResult({ match: data.match, alternatives: data.alternatives });
+        setSelectedPoint(data.match ?? null);
+        if (data.match) {
+          setSearchStatus(`Found ${data.match.label} on the map.`);
+        } else if (data.alternatives.length) {
+          setSearchStatus("Map label not found. Review suggestions.");
+        } else {
+          setSearchStatus("Map label not found.");
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        console.error(err);
+        setSearchStatus("Failed to resolve destination on map.");
+      }
+    };
+    fetchMatch();
+    return () => controller.abort();
+  }, [selectedMapId, destinationLabel, lastUpdatedKey]);
+
+  const handleMapChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = Number(event.target.value);
+    setSelectedMapId(Number.isFinite(value) ? value : null);
+    setSearchStatus(null);
+  };
+
+  const handleUploadSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!uploadFile) {
+      setAdminStatus("Select a map image before uploading.");
+      return;
+    }
+    try {
+      setUploading(true);
+      setAdminStatus("Uploading map…");
+      const formData = new FormData();
+      formData.append("image", uploadFile);
+      if (uploadState.name) formData.append("name", uploadState.name);
+      if (uploadState.floor) formData.append("floor", uploadState.floor);
+      if (uploadState.originLat) formData.append("georef_origin_lat", uploadState.originLat);
+      if (uploadState.originLon) formData.append("georef_origin_lon", uploadState.originLon);
+      if (uploadState.rotation) formData.append("georef_rotation_deg", uploadState.rotation);
+      if (uploadState.scale) formData.append("georef_scale_m_per_px", uploadState.scale);
+      const res = await fetch("/api/floor-maps", { method: "POST", body: formData });
+      if (!res.ok) throw new Error(await res.text());
+      const created = (await res.json()) as { map: FloorMapSummary };
+      await refreshMaps();
+      setSelectedMapId(created.map.id);
+      setUploadFile(null);
+      setUploadState(initialUploadState);
+      setAdminStatus("Map uploaded successfully.");
+    } catch (err) {
+      console.error(err);
+      setAdminStatus("Failed to upload map.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const selectedMap: BaseFloorMap | null = useMemo(() => {
+    if (!selectedMapId) return null;
+    return maps.find((map) => map.id === selectedMapId) ?? mapDetail?.map ?? null;
+  }, [maps, selectedMapId, mapDetail]);
+
+  const allPoints = mapDetail?.points ?? [];
+  const pointsForOverlay = useMemo(() => {
+    if (!selectedMap) return [];
+    return allPoints;
+  }, [selectedMap, allPoints]);
+
+  const handleMapClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!mapDetail?.map || !mapImageUrl) return;
+    const container = mapClickRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    const x = ((event.clientX - rect.left) / rect.width) * mapDetail.map.width;
+    const y = ((event.clientY - rect.top) / rect.height) * mapDetail.map.height;
+    setDraftPoint({ x, y });
+    setAnnotationLabel(annotationLabel || destinationLabel || "");
+    setAdminStatus(`Selected point at (${Math.round(x)}, ${Math.round(y)})`);
+  };
+
+  const handleSavePoint = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!selectedMapId || !draftPoint) return;
+    const label = annotationLabel.trim();
+    if (!label) {
+      setAdminStatus("Label is required to save a point.");
+      return;
+    }
+    try {
+      setAnnotationSaving(true);
+      setAdminStatus("Saving map point…");
+      const res = await fetch(`/api/floor-maps/${selectedMapId}/points`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          label,
+          x_px: draftPoint.x,
+          y_px: draftPoint.y,
+          synonyms: parseSynonyms(annotationSynonyms),
+        }),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      const updated = await fetch(`/api/floor-maps/${selectedMapId}`);
+      if (updated.ok) {
+        const data = (await updated.json()) as { map: BaseFloorMap; points: MapPoint[] };
+        setMapDetail({ map: { ...data.map, point_count: data.points.length }, points: data.points });
+        setMaps((prev) => prev.map((m) => (m.id === data.map.id ? { ...m, point_count: data.points.length } : m)));
+        setAdminStatus("Point saved to map.");
+        setDraftPoint(null);
+        setAnnotationLabel("");
+        setAnnotationSynonyms("");
+      } else {
+        setAdminStatus("Point saved but failed to refresh map.");
+      }
+    } catch (err) {
+      console.error(err);
+      setAdminStatus("Failed to save map point.");
+    } finally {
+      setAnnotationSaving(false);
+    }
+  };
+
+  const handleStartNavigation = async () => {
+    if (!selectedPoint || !selectedMap) {
+      setNavStatus("Select a destination point first.");
+      return;
+    }
+    try {
+      setNavStatus("Sending navigation payload…");
+      const payload = {
+        label: selectedPoint.label,
+        lat: selectedPoint.lat,
+        lon: selectedPoint.lon,
+        x_px: selectedPoint.x_px,
+        y_px: selectedPoint.y_px,
+        map_id: selectedMap.id,
+        floor: selectedMap.floor,
+        timestamp: new Date().toISOString(),
+        original_destination: destinationLabel ?? "",
+      };
+      const res = await fetch("/api/navigation/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error(await res.text());
+      setNavStatus("Navigation payload queued.");
+    } catch (err) {
+      console.error(err);
+      setNavStatus("Failed to send navigation payload.");
+    }
+  };
+
+  const displayPoint = selectedPoint;
+
+  return (
+    <div className="space-y-6">
+      <Card
+        className="bg-white"
+        header={
+          <div className="flex flex-col gap-1">
+            <h3 className="text-lg font-semibold text-gray-900">Floor Map Navigation</h3>
+            <p className="text-sm text-gray-500">
+              Resolve scanned destinations against your uploaded floor maps and send the location to the navigation module.
+            </p>
+          </div>
+        }
+      >
+        <div className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-3">
+            <div className="md:col-span-2 space-y-3">
+              <div className="rounded-md border border-gray-200 bg-gray-50 p-4">
+                <p className="text-sm font-semibold text-gray-700">Current Destination</p>
+                <p className="text-lg text-gray-900">{destinationLabel || "—"}</p>
+                {searchStatus && <p className="mt-1 text-sm text-gray-500">{searchStatus}</p>}
+              </div>
+              <div className="flex items-center gap-3">
+                <label className="flex flex-1 flex-col text-sm text-gray-700">
+                  <span className="mb-1 font-medium text-gray-900">Active Map</span>
+                  <select
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+                    value={selectedMapId ?? ""}
+                    onChange={handleMapChange}
+                  >
+                    <option value="" disabled>
+                      {loadingMaps ? "Loading maps…" : "Select a map"}
+                    </option>
+                    {maps.map((map) => (
+                      <option key={map.id} value={map.id}>
+                        {map.name} · {map.floor}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <Button variant="secondary" onClick={refreshMaps} disabled={loadingMaps}>
+                  Refresh
+                </Button>
+              </div>
+              {mapError && <p className="text-sm text-red-600">{mapError}</p>}
+            </div>
+            <div className="space-y-2 rounded-md border border-gray-200 p-4">
+              <p className="text-sm font-semibold text-gray-700">Navigation Payload</p>
+              <dl className="space-y-1 text-sm text-gray-600">
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-500">Label</dt>
+                  <dd className="font-medium text-gray-900">{displayPoint?.label ?? "—"}</dd>
+                </div>
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-500">Latitude</dt>
+                  <dd className="font-mono">{formatCoord(displayPoint?.lat ?? null)}</dd>
+                </div>
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-500">Longitude</dt>
+                  <dd className="font-mono">{formatCoord(displayPoint?.lon ?? null)}</dd>
+                </div>
+                <div className="flex justify-between gap-2">
+                  <dt className="text-gray-500">Local X / Y</dt>
+                  <dd className="font-mono">
+                    {displayPoint ? `${displayPoint.x_px.toFixed(1)}, ${displayPoint.y_px.toFixed(1)}` : "—"}
+                  </dd>
+                </div>
+              </dl>
+              <Button className="w-full" onClick={handleStartNavigation} disabled={!displayPoint}>
+                Start Navigation
+              </Button>
+              {navStatus && <p className="text-xs text-gray-500">{navStatus}</p>}
+            </div>
+          </div>
+
+          {mapImageUrl && selectedMap && (
+            <div className="relative overflow-hidden rounded-lg border border-gray-200 bg-gray-50">
+              <img src={mapImageUrl} alt={selectedMap.name} className="w-full object-contain" />
+              {displayPoint && (
+                <span
+                  className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-blue-600 p-1 shadow-md"
+                  style={buildMarkerStyle(displayPoint, selectedMap)}
+                  title={displayPoint.label}
+                />
+              )}
+            </div>
+          )}
+
+          {!displayPoint && searchResult.alternatives.length > 0 && (
+            <div className="rounded-md border border-yellow-300 bg-yellow-50 p-4">
+              <p className="text-sm font-semibold text-yellow-800">Suggestions</p>
+              <ul className="mt-2 space-y-2 text-sm text-yellow-900">
+                {searchResult.alternatives.map((alt) => (
+                  <li key={alt.id}>
+                    <button
+                      onClick={() => {
+                        setSelectedPoint(alt);
+                        setNavStatus(`Using suggestion ${alt.label}.`);
+                      }}
+                      className="text-left font-medium text-blue-700 hover:underline"
+                    >
+                      {alt.label}
+                    </button>
+                    {alt.synonyms.length > 0 && (
+                      <span className="ml-2 text-xs text-yellow-700">Synonyms: {alt.synonyms.join(", ")}</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card
+        className="bg-white"
+        header={
+          <div className="flex flex-col gap-1">
+            <h3 className="text-lg font-semibold text-gray-900">Map Administration</h3>
+            <p className="text-sm text-gray-500">
+              Upload new maps and annotate destination points. These annotations power the runtime destination lookup.
+            </p>
+          </div>
+        }
+      >
+        <div className="space-y-6">
+          <form className="grid gap-4 md:grid-cols-2" onSubmit={handleUploadSubmit}>
+            <div className="md:col-span-2">
+              <label className="text-sm text-gray-700">
+                <span className="mb-1 block font-medium text-gray-900">Floor Map Image</span>
+                <input
+                  type="file"
+                  accept="image/*"
+                  onChange={(event) => setUploadFile(event.target.files?.[0] ?? null)}
+                  className="block w-full text-sm text-gray-700"
+                />
+              </label>
+            </div>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Map Name</span>
+              <Input
+                value={uploadState.name}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, name: event.target.value }))}
+                placeholder="e.g. Main Floor"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Floor Identifier</span>
+              <Input
+                value={uploadState.floor}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, floor: event.target.value }))}
+                placeholder="e.g. floor1"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Origin Latitude</span>
+              <Input
+                value={uploadState.originLat}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, originLat: event.target.value }))}
+                placeholder="Optional"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Origin Longitude</span>
+              <Input
+                value={uploadState.originLon}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, originLon: event.target.value }))}
+                placeholder="Optional"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Rotation (° clockwise)</span>
+              <Input
+                value={uploadState.rotation}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, rotation: event.target.value }))}
+                placeholder="0"
+              />
+            </label>
+            <label className="text-sm text-gray-700">
+              <span className="mb-1 block font-medium text-gray-900">Scale (meters per pixel)</span>
+              <Input
+                value={uploadState.scale}
+                onChange={(event) => setUploadState((prev) => ({ ...prev, scale: event.target.value }))}
+                placeholder="1"
+              />
+            </label>
+            <div className="md:col-span-2">
+              <Button type="submit" disabled={uploading || !uploadFile}>
+                {uploading ? "Uploading…" : "Upload Floor Map"}
+              </Button>
+            </div>
+          </form>
+          {adminStatus && <p className="text-sm text-gray-500">{adminStatus}</p>}
+
+          {mapImageUrl && mapDetail?.map && (
+            <div className="space-y-4">
+              <div className="flex flex-wrap gap-4 text-sm text-gray-600">
+                <div>
+                  <span className="font-semibold text-gray-700">Selected map:</span> {mapDetail.map.name} ({mapDetail.map.floor})
+                </div>
+                <div>
+                  <span className="font-semibold text-gray-700">Dimensions:</span> {mapDetail.map.width} × {mapDetail.map.height} px
+                </div>
+                <div>
+                  <span className="font-semibold text-gray-700">Scale:</span> {formatMetric(mapDetail.map.georef_scale_m_per_px, "m/px")}
+                </div>
+              </div>
+              <div className="relative overflow-hidden rounded-lg border border-dashed border-blue-300 bg-blue-50">
+                <div
+                  ref={mapClickRef}
+                  className="relative cursor-crosshair"
+                  onClick={handleMapClick}
+                  role="presentation"
+                >
+                  <img src={mapImageUrl} alt={mapDetail.map.name} className="w-full object-contain" />
+                  {pointsForOverlay.map((point) => (
+                    <span
+                      key={point.id}
+                      className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-green-500 p-1"
+                      style={buildMarkerStyle(point, mapDetail.map)}
+                      title={point.label}
+                    />
+                  ))}
+                  {draftPoint && (
+                    <span
+                      className="absolute -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-orange-500 p-2"
+                      style={buildMarkerStyle(draftPoint, mapDetail.map)}
+                      title="New point"
+                    />
+                  )}
+                </div>
+              </div>
+              {draftPoint && (
+                <form className="grid gap-3 md:grid-cols-2" onSubmit={handleSavePoint}>
+                  <div className="md:col-span-2 text-sm text-gray-600">
+                    New point at {draftPoint.x.toFixed(1)}, {draftPoint.y.toFixed(1)} (pixels)
+                  </div>
+                  <label className="text-sm text-gray-700">
+                    <span className="mb-1 block font-medium text-gray-900">Destination Label</span>
+                    <Input value={annotationLabel} onChange={(event) => setAnnotationLabel(event.target.value)} />
+                  </label>
+                  <label className="text-sm text-gray-700">
+                    <span className="mb-1 block font-medium text-gray-900">Synonyms (comma separated)</span>
+                    <Input value={annotationSynonyms} onChange={(event) => setAnnotationSynonyms(event.target.value)} />
+                  </label>
+                  <div className="md:col-span-2 flex gap-3">
+                    <Button type="submit" disabled={annotationSaving}>
+                      {annotationSaving ? "Saving…" : "Save Point"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      onClick={() => {
+                        setDraftPoint(null);
+                        setAnnotationLabel("");
+                        setAnnotationSynonyms("");
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </form>
+              )}
+              <div>
+                <h4 className="text-sm font-semibold text-gray-700">Annotated Points</h4>
+                <div className="mt-2 max-h-64 overflow-y-auto">
+                  {pointsForOverlay.length === 0 ? (
+                    <p className="text-sm text-gray-500">No points have been added to this map yet.</p>
+                  ) : (
+                    <table className="min-w-full divide-y divide-gray-200 text-sm">
+                      <thead className="bg-gray-100 text-left text-xs font-semibold uppercase tracking-wider text-gray-600">
+                        <tr>
+                          <th scope="col" className="px-3 py-2">
+                            Label
+                          </th>
+                          <th scope="col" className="px-3 py-2">
+                            Coordinates (px)
+                          </th>
+                          <th scope="col" className="px-3 py-2">
+                            Lat / Lon
+                          </th>
+                          <th scope="col" className="px-3 py-2">
+                            Synonyms
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-200 bg-white">
+                        {pointsForOverlay.map((point) => (
+                          <tr key={point.id} className="hover:bg-gray-50">
+                            <td className="px-3 py-2 font-medium text-gray-900">{point.label}</td>
+                            <td className="px-3 py-2 font-mono text-gray-600">
+                              {point.x_px.toFixed(1)}, {point.y_px.toFixed(1)}
+                            </td>
+                            <td className="px-3 py-2 font-mono text-gray-600">
+                              {formatCoord(point.lat)} / {formatCoord(point.lon)}
+                            </td>
+                            <td className="px-3 py-2 text-gray-500">
+                              {point.synonyms.length ? point.synonyms.join(", ") : "—"}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+export default FloorMapModule;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -13,6 +13,41 @@ export interface OrderRecord {
   updated_at: string;
 }
 
+export interface FloorMapRecord {
+  id: number;
+  name: string;
+  image_path: string;
+  width: number;
+  height: number;
+  georef_origin_lat: number | null;
+  georef_origin_lon: number | null;
+  georef_rotation_deg: number | null;
+  georef_scale_m_per_px: number | null;
+  floor: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MapPointRecord {
+  id: number;
+  map_id: number;
+  label: string;
+  x_px: number;
+  y_px: number;
+  lat: number | null;
+  lon: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MapPointWithSynonyms extends MapPointRecord {
+  synonyms: string[];
+}
+
+export interface FloorMapSummary extends FloorMapRecord {
+  point_count: number;
+}
+
 let db: Database.Database | null = null;
 
 /**
@@ -46,6 +81,41 @@ function initDb() {
       alias TEXT PRIMARY KEY,
       code TEXT NOT NULL,
       FOREIGN KEY (code) REFERENCES orders(code) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS floor_maps (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      image_path TEXT NOT NULL,
+      width INTEGER NOT NULL,
+      height INTEGER NOT NULL,
+      georef_origin_lat REAL,
+      georef_origin_lon REAL,
+      georef_rotation_deg REAL,
+      georef_scale_m_per_px REAL,
+      floor TEXT NOT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS map_points (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      map_id INTEGER NOT NULL,
+      label TEXT NOT NULL,
+      x_px REAL NOT NULL,
+      y_px REAL NOT NULL,
+      lat REAL,
+      lon REAL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (map_id) REFERENCES floor_maps(id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS map_point_synonyms (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      point_id INTEGER NOT NULL,
+      synonym TEXT NOT NULL,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (point_id) REFERENCES map_points(id) ON DELETE CASCADE,
+      UNIQUE(point_id, synonym)
     );
   `);
 }
@@ -146,3 +216,244 @@ export function resolveItemCode(codeOrAlias: string): { code: string; floor: str
   // Ambiguous or not found
   return undefined;
 }
+
+const normalizeLabel = (label: string) => label.trim().toLowerCase();
+
+const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+
+const computeLatLonFromPx = (
+  map: FloorMapRecord,
+  x: number,
+  y: number,
+): { lat: number | null; lon: number | null } => {
+  const originLat = map.georef_origin_lat;
+  const originLon = map.georef_origin_lon;
+  const scale = map.georef_scale_m_per_px;
+  if (originLat == null || originLon == null || !scale || Number.isNaN(scale)) {
+    return { lat: originLat ?? null, lon: originLon ?? null };
+  }
+  const rotation = toRadians(map.georef_rotation_deg ?? 0);
+  const metersEast = x * scale;
+  const metersNorth = -y * scale;
+  const rotatedEast = metersEast * Math.cos(rotation) - metersNorth * Math.sin(rotation);
+  const rotatedNorth = metersEast * Math.sin(rotation) + metersNorth * Math.cos(rotation);
+  const metersPerDegreeLat = 111_320;
+  const metersPerDegreeLon = metersPerDegreeLat * Math.cos(toRadians(originLat));
+  if (!metersPerDegreeLon) {
+    return { lat: originLat + rotatedNorth / metersPerDegreeLat, lon: originLon };
+  }
+  return {
+    lat: originLat + rotatedNorth / metersPerDegreeLat,
+    lon: originLon + rotatedEast / metersPerDegreeLon,
+  };
+};
+
+const getMapPointRow = (id: number): MapPointWithSynonyms | undefined => {
+  const db = getDb();
+  const row = db.prepare(`SELECT * FROM map_points WHERE id = ?`).get(id) as MapPointRecord | undefined;
+  if (!row) return undefined;
+  const synonymRows = db
+    .prepare(`SELECT synonym FROM map_point_synonyms WHERE point_id = ? ORDER BY synonym`)
+    .all(id) as { synonym: string }[];
+  return { ...row, synonyms: synonymRows.map((s) => s.synonym) };
+};
+
+export interface MapPointSearchResult {
+  match: MapPointWithSynonyms | null;
+  alternatives: MapPointWithSynonyms[];
+}
+
+export const listFloorMaps = (): FloorMapSummary[] => {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT fm.*, (
+          SELECT COUNT(*) FROM map_points mp WHERE mp.map_id = fm.id
+        ) AS point_count
+       FROM floor_maps fm
+       ORDER BY fm.updated_at DESC`,
+    )
+    .all() as FloorMapSummary[];
+  return rows;
+};
+
+export const getFloorMapById = (id: number): FloorMapRecord | undefined => {
+  const db = getDb();
+  const row = db.prepare(`SELECT * FROM floor_maps WHERE id = ?`).get(id);
+  return row as FloorMapRecord | undefined;
+};
+
+export const createFloorMap = (payload: {
+  name: string;
+  imagePath: string;
+  width: number;
+  height: number;
+  georefOriginLat?: number | null;
+  georefOriginLon?: number | null;
+  georefRotationDeg?: number | null;
+  georefScaleMetersPerPixel?: number | null;
+  floor: string;
+}): FloorMapRecord => {
+  const db = getDb();
+  const info = db
+    .prepare(
+      `INSERT INTO floor_maps (
+        name,
+        image_path,
+        width,
+        height,
+        georef_origin_lat,
+        georef_origin_lon,
+        georef_rotation_deg,
+        georef_scale_m_per_px,
+        floor
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      payload.name,
+      payload.imagePath,
+      payload.width,
+      payload.height,
+      payload.georefOriginLat ?? null,
+      payload.georefOriginLon ?? null,
+      payload.georefRotationDeg ?? null,
+      payload.georefScaleMetersPerPixel ?? null,
+      payload.floor,
+    );
+  const id = Number(info.lastInsertRowid);
+  return getFloorMapById(id)!;
+};
+
+export const updateFloorMap = (
+  id: number,
+  updates: Partial<{
+    name: string;
+    georefOriginLat: number | null;
+    georefOriginLon: number | null;
+    georefRotationDeg: number | null;
+    georefScaleMetersPerPixel: number | null;
+    floor: string;
+  }>,
+): FloorMapRecord | undefined => {
+  const db = getDb();
+  const existing = getFloorMapById(id);
+  if (!existing) return undefined;
+  const next = {
+    name: updates.name ?? existing.name,
+    georef_origin_lat:
+      updates.georefOriginLat !== undefined ? updates.georefOriginLat : existing.georef_origin_lat,
+    georef_origin_lon:
+      updates.georefOriginLon !== undefined ? updates.georefOriginLon : existing.georef_origin_lon,
+    georef_rotation_deg:
+      updates.georefRotationDeg !== undefined ? updates.georefRotationDeg : existing.georef_rotation_deg,
+    georef_scale_m_per_px:
+      updates.georefScaleMetersPerPixel !== undefined
+        ? updates.georefScaleMetersPerPixel
+        : existing.georef_scale_m_per_px,
+    floor: updates.floor ?? existing.floor,
+  };
+  db.prepare(
+    `UPDATE floor_maps
+     SET name = ?,
+         georef_origin_lat = ?,
+         georef_origin_lon = ?,
+         georef_rotation_deg = ?,
+         georef_scale_m_per_px = ?,
+         floor = ?,
+         updated_at = CURRENT_TIMESTAMP
+     WHERE id = ?`,
+  ).run(
+    next.name,
+    next.georef_origin_lat,
+    next.georef_origin_lon,
+    next.georef_rotation_deg,
+    next.georef_scale_m_per_px,
+    next.floor,
+    id,
+  );
+  return getFloorMapById(id) ?? undefined;
+};
+
+export const listMapPoints = (mapId: number): MapPointWithSynonyms[] => {
+  const db = getDb();
+  const rows = db
+    .prepare(
+      `SELECT mp.*, GROUP_CONCAT(mps.synonym, '\u0001') AS synonyms
+       FROM map_points mp
+       LEFT JOIN map_point_synonyms mps ON mps.point_id = mp.id
+       WHERE mp.map_id = ?
+       GROUP BY mp.id
+       ORDER BY mp.label COLLATE NOCASE`,
+    )
+    .all(mapId) as (MapPointRecord & { synonyms: string | null })[];
+  return rows.map((row) => ({
+    ...row,
+    synonyms: row.synonyms ? row.synonyms.split('\u0001').filter(Boolean) : [],
+  }));
+};
+
+export const createMapPoint = (payload: {
+  mapId: number;
+  label: string;
+  x_px: number;
+  y_px: number;
+  synonyms?: string[];
+}): MapPointWithSynonyms => {
+  const map = getFloorMapById(payload.mapId);
+  if (!map) throw new Error(`Map ${payload.mapId} not found`);
+  const coords = computeLatLonFromPx(map, payload.x_px, payload.y_px);
+  const db = getDb();
+  const info = db
+    .prepare(
+      `INSERT INTO map_points (map_id, label, x_px, y_px, lat, lon)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(payload.mapId, payload.label.trim(), payload.x_px, payload.y_px, coords.lat, coords.lon);
+  const pointId = Number(info.lastInsertRowid);
+  if (payload.synonyms?.length) {
+    const stmt = db.prepare(
+      `INSERT OR IGNORE INTO map_point_synonyms (point_id, synonym)
+       VALUES (?, ?)`,
+    );
+    for (const synonym of payload.synonyms) {
+      const trimmed = synonym.trim();
+      if (trimmed) stmt.run(pointId, trimmed);
+    }
+  }
+  const point = getMapPointRow(pointId);
+  if (!point) throw new Error('Failed to create map point');
+  return point;
+};
+
+export const addSynonymsToPoint = (pointId: number, synonyms: string[]) => {
+  if (!synonyms.length) return;
+  const db = getDb();
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO map_point_synonyms (point_id, synonym)
+     VALUES (?, ?)`,
+  );
+  for (const synonym of synonyms) {
+    const trimmed = synonym.trim();
+    if (trimmed) stmt.run(pointId, trimmed);
+  }
+};
+
+export const searchMapPoint = (mapId: number, label: string): MapPointSearchResult => {
+  const points = listMapPoints(mapId);
+  const target = normalizeLabel(label);
+  if (!target) return { match: null, alternatives: points.slice(0, 5) };
+  const match = points.find((point) => {
+    if (normalizeLabel(point.label) === target) return true;
+    return point.synonyms.some((syn) => normalizeLabel(syn) === target);
+  });
+  if (match) {
+    return { match, alternatives: points.filter((p) => p.id !== match.id).slice(0, 5) };
+  }
+  const alternatives = points
+    .filter((point) => {
+      if (point.label && normalizeLabel(point.label).includes(target)) return true;
+      return point.synonyms.some((syn) => normalizeLabel(syn).includes(target));
+    })
+    .slice(0, 5);
+  return { match: null, alternatives };
+};


### PR DESCRIPTION
## Summary
- extend the SQLite layer with floor map, map point, and synonym tables plus helper utilities for georeferencing
- add REST endpoints to upload maps, manage annotations, resolve destinations, and stub the navigation hand-off
- build a floor map module on the scanner dashboard with admin tooling, runtime lookup, and document QA scenarios

## Testing
- manual scenario checklist added in docs/map-testing.md
